### PR TITLE
(PCP-197) Acceptance tests should no longer expect unconfigured mode

### DIFF
--- a/acceptance/tests/invalid_ssl_config.rb
+++ b/acceptance/tests/invalid_ssl_config.rb
@@ -37,14 +37,12 @@ agents.each_with_index do |agent, i|
   step 'C94730 - Attempt to run pxp-agent with mismatching SSL cert and private key' do
     on agent, puppet('resource service pxp-agent ensure=running')
     expect_file_on_host_to_contain(agent, logfile(agent), 'failed to load private key')
-    assert(on(agent, "grep 'pxp-agent will start unconfigured' #{logfile(agent)}"),
-         "pxp-agent should log that is will start unconfigured")
     on agent, puppet('resource service pxp-agent') do |result|
-      assert_match(/running/, result.stdout, "pxp-agent service should be running (unconfigured)")
+      assert_match(/stopped/, result.stdout, "pxp-agent service should not be running due to invalid SSL config")
     end
   end
 
-  step "Stop pxp-agent service and wipe log" do
+  step "Ensure pxp-agent service is stopped, and wipe log" do
     on agent, puppet('resource service pxp-agent ensure=stopped')
     on(agent, "rm -rf #{logfile(agent)}")
   end

--- a/acceptance/tests/service_stop_start.rb
+++ b/acceptance/tests/service_stop_start.rb
@@ -66,11 +66,6 @@ agents.each_with_index do |agent, i|
 
     step 'C94686 - Service Start (from stopped, un-configured)' do
       start_service
-      assert_running
-    end
-
-    step 'C94687 - Service Stop (from running, un-configured)' do
-      stop_service
       assert_stopped
     end
 


### PR DESCRIPTION
Change anywhere that test cases expect unconfigured mode for pxp-agent. pxp-agent will now exit if it is unable to run with configuration.
